### PR TITLE
[Feat] #171 - Footer지도탭& 중개사무소 지도 수정

### DIFF
--- a/HomeWorry/src/components/layout/Footer.vue
+++ b/HomeWorry/src/components/layout/Footer.vue
@@ -5,7 +5,7 @@
         v-for="tab in tabs"
         :key="tab.name"
         :to="tab.to"
-        class="tab-item bodyLight12px"
+        class="tab-item bodyLight10px"
         active-class="active"
         @click="onTabClick()"
       >
@@ -90,7 +90,7 @@ function onTabClick() {
   display: flex;
   justify-content: space-around;
   align-items: center;
-  height: 70px;
+  height: 64px;
   border-top: 1px solid var(--color-light);
 }
 
@@ -105,9 +105,9 @@ function onTabClick() {
 }
 
 .tab-icon {
-  width: 28px;
-  height: 28px;
-  margin-bottom: 5px;
+  width: 24px;
+  height: 24px;
+  margin-bottom: 6px;
 }
 
 .tab-item.active {

--- a/HomeWorry/src/pages/agency/AgencyListPage.vue
+++ b/HomeWorry/src/pages/agency/AgencyListPage.vue
@@ -54,7 +54,7 @@ const agencies = ref([])
 
 // 페이지네이션 상태
 const page = ref(1)
-const pageSize = 20
+const pageSize = 10
 
 onMounted(async () => {
   try {

--- a/HomeWorry/src/pages/map/MapAgencyPage.vue
+++ b/HomeWorry/src/pages/map/MapAgencyPage.vue
@@ -7,7 +7,7 @@
       :markerCluster="{
         customOverlayProps: agencies,
         calculator: [10, 30, 50],
-        minLevel: 3,
+        minLevel: 4,
         styles: [
           {
             width: '30px',
@@ -54,63 +54,34 @@
       @onLoadKakaoMap="onMapReady"
       style="width: 100%; height: 100%"
     >
-      <template v-if="level < 3">
-        <template v-for="(marker, index) in agencies" :key="marker.officeId">
+      <!-- level 4 부터 줌인 시 커스텀 핀 표시 -->
+      <template v-if="level < 4">
+        <template v-for="marker in agencies" :key="marker.officeId">
           <KakaoMapMarker
             :lat="marker.lat"
             :lng="marker.lng"
             :clickable="true"
             :image="{
-              imageSrc: '/map_agency_pin.png',
+              imageSrc: pinSrc,
               imageWidth: 36,
-              imageHeight: 36,
-              imageOption: {}
+              imageHeight: 36
             }"
             @onClickKakaoMapMarker="() => onMarkerClick(marker)"
           />
+
+          <!-- 선택된 항목만 커스텀 오버레이(분리한 컴포넌트 사용) -->
           <template v-if="selectedAgency && selectedAgency.officeId === marker.officeId">
-            <KakaoMapCustomOverlay :lat="marker.lat" :lng="marker.lng">
-              <div
-                style="
-                  padding: 10px;
-                  background-color: white;
-                  border: 1px solid #ccc;
-                  border-radius: 5px;
-                  display: flex;
-                  flex-direction: column;
-                  align-items: flex-start;
-                "
-              >
-                <div style="font-weight: bold; margin-bottom: 5px">
-                  {{ selectedAgency.officeName }}
-                </div>
-                <div style="display: flex">
-                  <div style="margin-right: 10px">
-                    <img
-                      src="https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/thumnail.png"
-                      width="73"
-                      height="70"
-                    />
-                  </div>
-                  <div style="display: flex; flex-direction: column; align-items: flex-start;">
-                    <div style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
-                      {{ selectedAgency.agentName }}
-                    </div>
-                    <div style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
-                      {{ selectedAgency.address }}
-                    </div>
-                    <div>
-                      <a
-                        href="https://www.kakaocorp.com/main"
-                        target="_blank"
-                        style="color: blue"
-                      >
-                        {{ selectedAgency.phone }}
-                      </a>
-                    </div>
-                  </div>
-                </div>
-              </div>
+            <KakaoMapCustomOverlay
+              :lat="marker.lat"
+              :lng="marker.lng"
+              :z-index="9999"
+            >
+              <MapAgencyCard
+                :agency="selectedAgency"
+                @close="selectedAgency = null"
+                @detail="goDetail"
+                @bookmark="onBookmark"
+              />
             </KakaoMapCustomOverlay>
           </template>
         </template>
@@ -122,8 +93,10 @@
 <script setup>
 import { ref, onMounted } from "vue";
 import { useRoute, useRouter } from "vue-router";
-import { KakaoMap, KakaoMapMarker, KakaoMapCustomOverlay } from "vue3-kakao-maps";
+import { KakaoMap, KakaoMapMarker, KakaoMapCustomOverlay} from "vue3-kakao-maps";
+import MapAgencyCard from "@/pages/map/components/MapAgencyCard.vue";
 
+const pinSrc = `${import.meta.env.BASE_URL}map_agency_pin.png`;
 const route = useRoute();
 const router = useRouter();
 
@@ -136,7 +109,7 @@ const agency_map = ref(null);
 const customOverlay = ref(null);
 const agencies = ref([]);
 const selectedAgency = ref(null);
-const map = ref();
+const map = ref(null);
 const clusterer = ref();
 
 onMounted(() => {
@@ -157,6 +130,18 @@ const onLoadKakaoMapMarkerCluster = (clustererRef) => {
     }
   });
 };
+
+// 맵 빈 곳 클릭 시 오버레이 닫기
+function onMapReady(mapRef) {
+  map.value = mapRef;
+
+  kakao.maps.event.addListener(mapRef, "click", () => {
+    selectedAgency.value = null;
+  });
+
+  kakao.maps.event.addListener(mapRef, "dragend", () => updateURL(mapRef));
+  kakao.maps.event.addListener(mapRef, "zoom_changed", () => updateURL(mapRef));
+}
 
 async function loadAgencies() {
   try {
@@ -181,22 +166,33 @@ async function onMarkerClick(agency) {
     const response = await fetch(`http://localhost:8080/api/agent/${agency.officeId}`);
     if (!response.ok) throw new Error("Network response was not ok");
     const data = await response.json();
+    // 선택한 마커 좌표를 같이 보관
     selectedAgency.value = { ...data, lat: agency.lat, lng: agency.lng };
-    console.log(selectedAgency.value);
+        console.log(selectedAgency.value);
   } catch (e) {
     alert("중개사무소 정보를 불러오지 못했습니다.");
   }
 }
 
-function onMapReady(map) {
-  kakao.maps.event.addListener(map, "dragend", () => updateURL(map));
-  kakao.maps.event.addListener(map, "zoom_changed", () => updateURL(map));
-  agency_map.value = map;
+// 2) 상세보기 액션: 라우터 이동 (route name/param은 프로젝트에 맞게 수정)
+function goDetail(officeId) {
+  router.push({ name: "agencyDetail", params: { agencyId: officeId } });
 }
 
-function updateURL(map) {
-  const center = map.getCenter();
-  const zoom = map.getLevel();
+// 2) 북마크 액션: 실제 API 연동/상태 반영은 프로젝트 로직에 맞게 교체
+async function onBookmark(officeId) {
+  try {
+    // 예시: await fetch('/api/bookmark', { method:'POST', body: JSON.stringify({ officeId }) })
+    console.log("bookmark:", officeId);
+    alert("북마크에 추가했습니다.");
+  } catch {
+    alert("북마크 추가에 실패했습니다.");
+  }
+}
+
+function updateURL(mapRef) {
+  const center = mapRef.getCenter();
+  const zoom = mapRef.getLevel();
   router.replace({
     query: {
       ...route.query,
@@ -210,25 +206,6 @@ function updateURL(map) {
 }
 </script>
 
-<style>
-.custom-overlay {
-  padding: 10px;
-  background-color: white;
-  border: 1px solid #ccc;
-  border-radius: 5px;
-  position: relative;
-  min-width: 200px;
-}
-.custom-overlay .title {
-  font-weight: bold;
-  font-size: 16px;
-  margin-bottom: 5px;
-}
-.custom-overlay .close-btn {
-  position: absolute;
-  top: 5px;
-  right: 5px;
-  cursor: pointer;
-  font-weight: bold;
-}
+<style scoped>
+/* 오버레이 자체 스타일은 분리한 컴포넌트(AgencyOverlayCard.vue) 내부에 있음 */
 </style>

--- a/HomeWorry/src/pages/map/MapAgencyPage.vue
+++ b/HomeWorry/src/pages/map/MapAgencyPage.vue
@@ -76,12 +76,11 @@
               :lng="marker.lng"
               :z-index="9999"
             >
-              <MapAgencyCard
-                :agency="selectedAgency"
-                @close="selectedAgency = null"
-                @detail="goDetail"
-                @bookmark="onBookmark"
-              />
+            <MapAgencyCard
+              :agency="selectedAgency"
+              @close="selectedAgency = null"
+              @detail="goDetail"
+            />
             </KakaoMapCustomOverlay>
           </template>
         </template>
@@ -131,13 +130,9 @@ const onLoadKakaoMapMarkerCluster = (clustererRef) => {
   });
 };
 
-// 맵 빈 곳 클릭 시 오버레이 닫기
 function onMapReady(mapRef) {
   map.value = mapRef;
 
-  kakao.maps.event.addListener(mapRef, "click", () => {
-    selectedAgency.value = null;
-  });
 
   kakao.maps.event.addListener(mapRef, "dragend", () => updateURL(mapRef));
   kakao.maps.event.addListener(mapRef, "zoom_changed", () => updateURL(mapRef));
@@ -167,7 +162,7 @@ async function onMarkerClick(agency) {
     if (!response.ok) throw new Error("Network response was not ok");
     const data = await response.json();
     // 선택한 마커 좌표를 같이 보관
-    selectedAgency.value = { ...data, lat: agency.lat, lng: agency.lng };
+    selectedAgency.value = { ...data, officeId: agency.officeId, lat: agency.lat, lng: agency.lng };
         console.log(selectedAgency.value);
   } catch (e) {
     alert("중개사무소 정보를 불러오지 못했습니다.");
@@ -176,7 +171,17 @@ async function onMarkerClick(agency) {
 
 // 2) 상세보기 액션: 라우터 이동 (route name/param은 프로젝트에 맞게 수정)
 function goDetail(officeId) {
-  router.push({ name: "agencyDetail", params: { agencyId: officeId } });
+  const id =
+    officeId ??
+    selectedAgency.value?.officeId ??
+    selectedAgency.value?.office_id ??
+    selectedAgency.value?.id;
+
+  if (!id) {
+    console.warn('[goDetail] agency id missing', officeId, selectedAgency.value);
+    return;
+  }
+  router.push({ name: 'agencyDetail', params: { agencyId: String(id) } });
 }
 
 // 2) 북마크 액션: 실제 API 연동/상태 반영은 프로젝트 로직에 맞게 교체

--- a/HomeWorry/src/pages/map/MapPage.vue
+++ b/HomeWorry/src/pages/map/MapPage.vue
@@ -1,77 +1,37 @@
 <template>
-  <div style="width: 100%; height: 100vh">
-    <div class="flex gap-4 p-4">
+  <div style="width: 100%; height: 100vh; position: relative">
+    <!-- 상단 FilterBar (면적/거래유형/검색) -->
+    <div class="top-controls">
+      <FilterBar
+        :minPyeong="minPyeong"
+        :maxPyeong="maxPyeong"
+        :selectedTransactionType="selectedTransactionType"
+        :sheet-open="isBottomSheetOpen"
+        @update:minPyeong="val => (minPyeong = val)"
+        @update:maxPyeong="val => (maxPyeong = val)"
+        @update:transactionType="val => (selectedTransactionType = val)"
+        @update:sheet-open="val => (isBottomSheetOpen = val)"
+        @search="onSearchLocation"
+      />
+    </div>
+
+    <!-- 카테고리 칩 6개 (2줄 텍스트, 정사각형 느낌) -->
+    <div class="chip-row bodyMedium10px">
       <button
-        @click="moveToCurrentLocation"
-        class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+        v-for="btn in categoryButtons"
+        :key="btn.id"
+        @click="toggleCategory(btn.id)"
+        :class="[
+          'chip',
+          { active: activeCats.has(btn.id) },
+          btn.id.startsWith('price-') ? 'price' : 'list'
+        ]"
       >
-        Current Location
+        {{ btn.label }}
       </button>
-      <div :class="randomBgClass" class="bg-opacity-30 p-2 rounded">
-        <label
-          v-for="type in ['아파트', '연립다세대', '오피스텔']"
-          :key="type"
-          class="flex items-center gap-1"
-        >
-          <input type="checkbox" :value="type" v-model="selectedHousingTypes" />
-          {{ type }}
-        </label>
-      </div>
-    </div>
-    <!-- Listing types checkboxes -->
-    <div class="flex gap-4 p-4">
-      <div :class="randomBgClass" class="bg-opacity-30 p-2 rounded">
-        <label
-          v-for="type in [
-            '원룸',
-            '오피스텔',
-            '빌라',
-            '단독/다가구',
-            '상가주택',
-            '다세대',
-            '최근',
-          ]"
-          :key="type"
-          class="flex items-center gap-1"
-        >
-          <input type="checkbox" :value="type" v-model="selectedListingTypes" />
-          {{ type }}
-        </label>
-        <FilterBar
-          :minPyeong="minPyeong"
-          :maxPyeong="maxPyeong"
-          @updatePyeong="handlePyeongUpdate"
-        />
-
-        Current filter display
-        <div class="flex items-center gap-2 mt-2 p-2 bg-gray-100 rounded">
-          <span class="text-sm font-medium">현재 필터:</span>
-          <span class="text-sm">
-            평수: {{ minPyeong || '전체' }} ~ {{ maxPyeong || '전체' }}
-          </span>
-          <span class="text-sm">
-            | 거래유형: {{ selectedTransactionType || '전체' }}
-          </span>
-          <span class="text-sm"> | 매물수: {{ listingMarkers.length }}개 </span>
-        </div>
-
-        <div class="flex items-center gap-2 mt-2">
-          <label>거래 유형:</label>
-          <select
-            v-model="selectedTransactionType"
-            class="border px-2 py-1 rounded"
-          >
-            <option value="">전체</option>
-            <option value="전세">전세</option>
-            <option value="월세">월세</option>
-            <option value="단기임대">단기임대</option>
-          </select>
-        </div>
-      </div>
     </div>
 
-    <ListingToggle :visible="isListingsVisible" @toggle="toggleListings" />
-
+    <!-- 카카오맵 -->
     <KakaoMap
       :lat="lat"
       :lng="lng"
@@ -79,442 +39,317 @@
       @onLoadKakaoMap="onMapReady"
       style="width: 100%; height: 100%"
     >
-      <!-- Price Markers with Custom Overlays -->
-      <!--  :markerCluster="{ customOverlayProps: markers }"  -->
-      <template
-        v-if="level >= 4"
-        v-for="(dongMarker, index) in dongMarkers"
-        :key="index"
-      >
-        <KakaoMapCustomOverlay
-          :lat="dongMarker.lat"
-          :lng="dongMarker.lng"
-          :y-anchor="1.4"
-        >
-          <div class="custom-overlay">
-            <!-- {{ (dongMarker.dongName, dongMarker.price) }} -->
-            <span class="bg-red-500 text-white px-2 py-1 rounded">
-              {{ dongMarker.dongName }})
-            </span>
-            {{ dongMarker.price }}
-            <!-- {{ dongMarker }} -->
-          </div>
-        </KakaoMapCustomOverlay>
+      <!-- 시세 레이어(아파트/오피스텔/연립다세대) -->
+      <template v-if="level < 5">
+        <template v-for="(marker, index) in visiblePriceMarkers" :key="'price-'+index">
+          <KakaoMapCustomOverlay :lat="marker.lat" :lng="marker.lng" :y-anchor="1.4">
+            <MarketPriceDetail :price="marker.price" :housingType="marker.housingType" />
+          </KakaoMapCustomOverlay>
+        </template>
       </template>
 
-      <template
-        v-if="level < 4"
-        v-for="(marker, index) in markers"
-        :key="index"
-      >
-        <KakaoMapCustomOverlay
-          :lat="marker.lat"
-          :lng="marker.lng"
-          :y-anchor="1.4"
-        >
-          <!-- click 추가 -->
-          <!-- <div class="custom-overlay" @click="goToDetail(marker)"> -->
-          <div class="custom-overlay">
-            <span @click="console.log(marker)"> {{ marker }}</span>
-            <!-- <span> {{ marker.price }}</span> -->
-          </div>
-        </KakaoMapCustomOverlay>
-      </template>
-      <!-- listingMarkers 지도에 표시 -->
-      <template
-        v-if="level < 4 && isListingsVisible"
-        v-for="(marker, index) in listingMarkers"
-        :key="'listing-' + index"
-      >
-        <KakaoMapCustomOverlay
-          :lat="marker.lat"
-          :lng="marker.lng"
-          :y-anchor="1.4"
-        >
-          <!-- <div
-            class="custom-overlay text-white"
-            style="background-color: #1e3a8a"
-            @click="goToDetail(marker)"
-            > -->
-          <div
-            class="custom-overlay text-white"
-            style="background-color: #1e3a8a"
-            @click="console.log(marker.areaInfo2)"
+      <!-- 매물 레이어(원룸/빌라/오피스텔) → FilterBar의 면적/거래유형 필터가 여기 반영됨 -->
+      <template v-if="level < 5 && isListingsVisible">
+        <template v-for="(marker, index) in visibleListingMarkers" :key="'listing-'+index">
+          <KakaoMapCustomOverlay
+            :lat="marker.lat"
+            :lng="marker.lng"
+            :y-anchor="1.4"
+            @click="goDetail(marker.id)"
           >
-            {{ marker.areaInfo2 }}
-          </div>
-        </KakaoMapCustomOverlay>
+            <ListingMarkers :marker="marker" />
+          </KakaoMapCustomOverlay>
+        </template>
       </template>
     </KakaoMap>
 
-    <h1 class="dong-label bg-opacity-50" :class="randomBgClass">
-      📍 {{ currentDong }} ({{ mapCenter.lat.toFixed(4) }},
-      {{ mapCenter.lng.toFixed(4) }})
-      {{ level }}
-    </h1>
+    <!-- 플로팅 버튼 스택 -->
+    <FloatingButtonStack
+      v-if="!isBottomSheetOpen"
+      @zoom-in="zoomIn"
+      @zoom-out="zoomOut"
+      @move-current-location="moveToCurrentLocation"
+    />
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted, watch } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
-import { KakaoMap, KakaoMapCustomOverlay } from 'vue3-kakao-maps';
-import FilterBar from './components/FilterBar.vue';
+import { ref, computed, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { KakaoMap, KakaoMapCustomOverlay } from 'vue3-kakao-maps'
 
-const route = useRoute();
-const router = useRouter();
+import FilterBar from '@/pages/map/components/FilterBar.vue'
+import MarketPriceDetail from '@/pages/map/components/MarketPriceDetail.vue'
+import FloatingButtonStack from '@/pages/map/components/FloatingButtonStack.vue'
+import ListingMarkers from '@/pages/map/components/ListingMarkers.vue'
 
-const minPyeong = ref(null);
-const maxPyeong = ref(null);
+/** 라우터는 센터/줌 동기화만 */
+const route = useRoute()
+const router = useRouter()
 
-const handlePyeongUpdate = (pyeong) => {
-  // Update the area filter values from the FilterBar component
-  minPyeong.value = pyeong.min;
-  maxPyeong.value = pyeong.max;
-  // Manually trigger loadListings() to refresh the data
-  loadListings();
-  console.log('Area filter updated:', pyeong);
-};
+const lat = ref(route.query.center?.split(',').map(Number)[0] || 37.5435)
+const lng = ref(route.query.center?.split(',').map(Number)[1] || 127.0812)
+const level = ref(Number(route.query.zoomLevel) || 4)
+const mapInstance = ref(null)
 
-const lat = ref(route.query.center?.split(',').map(Number)[0] || 37.5435);
-const lng = ref(route.query.center?.split(',').map(Number)[1] || 127.0812);
-const currentLocation = ref(null);
-const level = ref(Number(route.query.zoomLevel) || 8);
+const isBottomSheetOpen = ref(false)
+const isListingsVisible = ref(true)
 
-const getCurrentLocation = (successCallback, errorCallback) => {
-  if (navigator.geolocation) {
-    navigator.geolocation.getCurrentPosition(
-      (position) => {
-        const lat = position.coords.latitude;
-        const lng = position.coords.longitude;
-        successCallback({ lat, lng });
-      },
-      (error) => {
-        console.error('Geolocation error:', error);
-        errorCallback();
-      }
-    );
-  } else {
-    console.error('Geolocation is not supported by this browser.');
-    errorCallback();
-  }
-};
+const currentLocation = ref(null)
+const mapCenter = ref({ lat: lat.value, lng: lng.value })
 
-const moveToCurrentLocation = () => {
-  if (currentLocation.value && mapInstance.value) {
-    const newCenter = new window.kakao.maps.LatLng(
-      currentLocation.value.lat,
-      currentLocation.value.lng
-    );
-    mapInstance.value.panTo(newCenter);
-    mapInstance.value.setLevel(3);
-    updateURL(mapInstance.value);
-  }
-};
+/** FilterBar 상태 */
+const minPyeong = ref(null)
+const maxPyeong = ref(null)
+const selectedTransactionType = ref([]) // ['전세','월세','매매'] 등
 
-const markers = ref([]);
-const dongMarkers = ref([]);
-const mapInstance = ref(null);
-const currentDong = ref('');
-const mapCenter = ref({ lat: lat.value, lng: lng.value });
-const randomBgClass = ref('bg-white'); // Initial Tailwind background class
+/** 칩 6개 */
+const categoryButtons = [
+  { id: 'price-apartment', label: '아파트\n시세' },
+  { id: 'price-officetel', label: '오피스텔\n시세' },
+  { id: 'price-villa', label: '연립-\n다세대\n시세' },
+  { id: 'list-oneroom', label: '원룸\n매물' },
+  { id: 'list-villa', label: '빌라-\n다가구\n매물' },
+  { id: 'list-officetel', label: '오피스텔\n매물' }
+]
 
-const listingMarkers = ref([]);
-const selectedListingTypes = ref([
-  '원룸',
-  '오피스텔',
-  '빌라',
-  '단독/다가구',
-  '상가주택',
-  '다세대',
-  '최근',
-]);
-const selectedHousingTypes = ref(['아파트', '연립다세대', '오피스텔']);
-const selectedTransactionType = ref('');
+const activeCats = ref(new Set())
 
-// Tailwind CSS background colors for the label
-const tailwindBgColors = [
-  'bg-red-500',
-  'bg-blue-500',
-  'bg-green-500',
-  'bg-yellow-500',
-  'bg-purple-500',
-  'bg-pink-500',
-  'bg-indigo-500',
-  'bg-teal-500',
-  'bg-orange-500',
-];
+const allPriceMarkers = ref([]) 
+const allListings = ref([])    
+const loaded = ref({ price: false, listing: false })
 
-onMounted(() => {
-  getCurrentLocation(
-    (location) => {
-      lat.value = location.lat;
-      lng.value = location.lng;
-      currentLocation.value = location;
-      mapCenter.value = location;
-      loadAllData();
-    },
-    () => {
-      console.error('Failed to get current location, using default.');
-      loadAllData();
-    }
-  );
-});
-
-async function loadAllData() {
-  await loadPricelist();
-  await loadMaximumList();
-  await loadListings();
+/** 칩 → 타입 매핑 */
+const priceTypeByCat = {
+  'price-apartment': ['아파트'],
+  'price-officetel': ['오피스텔'],
+  'price-villa': ['연립다세대']
+}
+const listingTypeByCat = {
+  'list-oneroom': ['원룸'],
+  'list-villa': ['단독/다가구', '빌라', '상가주택', '다세대'],
+  'list-officetel': ['오피스텔']
 }
 
-watch(selectedHousingTypes, () => {
-  loadPricelist();
-});
-watch(selectedListingTypes, () => {
-  loadListings();
-});
+/** 표시용 computed */
+const visiblePriceMarkers = computed(() => {
+  if (!loaded.value.price) return []
+  const wanted = Object.entries(priceTypeByCat)
+    .filter(([cat]) => activeCats.value.has(cat))
+    .flatMap(([, t]) => t)
+  if (!wanted.length) return []
+  return allPriceMarkers.value.filter(m => wanted.includes(m.housingType))
+})
 
-watch(selectedTransactionType, () => {
-  loadListings();
-});
+const visibleListingMarkers = computed(() => {
+  if (!loaded.value.listing) return []
+  const wanted = Object.entries(listingTypeByCat)
+    .filter(([cat]) => activeCats.value.has(cat))
+    .flatMap(([, t]) => t)
+  if (!wanted.length) return []
 
-// Watch for area filter changes - removed to prevent infinite loop
-// The loadListings() will be called manually when FilterBar emits updatePyeong
+  // FilterBar의 면적/거래유형 필터를 반영
+  return allListings.value.filter(m =>
+    wanted.includes(m.housingType) &&
+    m.areaInfo2 !== null &&
+    (minPyeong.value === null || m.areaInfo2 >= minPyeong.value) &&
+    (maxPyeong.value === null || m.areaInfo2 <= maxPyeong.value) &&
+    (!selectedTransactionType.value.length ||
+      selectedTransactionType.value.includes(m.transactionType))
+  )
+})
 
-async function loadMaximumList() {
-  try {
-    const response = await fetch('/maximums.csv');
-    const csvText = await response.text();
-    const lines = csvText.split('\n');
-    const headers = lines[0].split(',');
-    const priceIndex = headers.indexOf('THING_AMT_KOR');
-    const latIndex = headers.indexOf('latitude');
-    const lonIndex = headers.indexOf('longitude');
-    const dongName = headers.indexOf('STDG_NM');
+function toggleCategory(catId) {
+  const next = new Set(activeCats.value)
+  next.has(catId) ? next.delete(catId) : next.add(catId)
+  activeCats.value = next
 
-    const loadedMarkers = [];
-    for (let i = 1; i < lines.length; i++) {
-      const line = lines[i];
-      if (line) {
-        const values = line.split(',');
-        const latitude = parseFloat(values[latIndex]);
-        const longitude = parseFloat(values[lonIndex]);
-        if (!isNaN(latitude) && !isNaN(longitude)) {
-          loadedMarkers.push({
-            lat: latitude,
-            lng: longitude,
-            price: values[priceIndex],
-            dongName: values[dongName],
-          });
-        }
-      }
-    }
-    dongMarkers.value = loadedMarkers;
-  } catch (error) {
-    console.error('Error loading or parsing pricelist.csv:', error);
-  }
+  if (catId.startsWith('price-') && !loaded.value.price) loadPrices()
+  if (catId.startsWith('list-')  && !loaded.value.listing) loadListings()
 }
 
-// Load pricelist data
-async function loadPricelist() {
+/** 데이터 로딩 */
+async function loadPrices() {
   try {
-    const response = await fetch('/api/pricetrend'); // ✅ API 호출
-    const data = await response.json(); // ✅ JSON 파싱
-
-    const loadedMarkers = data.map((item) => ({
+    const res = await fetch('/api/pricetrend')
+    const data = await res.json()
+    allPriceMarkers.value = data.map(item => ({
       lat: item.latitude,
       lng: item.longitude,
-      price: item.price || item.monthlyRent || '가격없음', // 상황에 따라 적절한 필드 사용
+      price: item.price || item.monthlyRent || '가격없음',
       id: item.id,
-      year: item.year,
-      districtCode: item.districtCode,
-      districtName: item.districtName,
-      dongCode: item.dongCode,
-      dongName: item.dongName,
-      lotTypeCode: item.lotTypeCode,
-      lotType: item.lotType,
-      mainNo: item.mainNo,
-      subNo: item.subNo,
-      buildingName: item.buildingName,
-      contractDay: item.contractDay,
-      archArea: item.archArea,
-      landArea: item.landArea,
-      floor: item.floor,
-      builtYear: item.builtYear,
-      housingType: item.housingType,
-      dealType: item.dealType,
-      address: item.address,
-    }));
-
-    markers.value = loadedMarkers.filter((marker) =>
-      selectedHousingTypes.value.includes(marker.housingType)
-    );
-  } catch (error) {
-    console.error('❌ API 로딩 실패:', error);
+      housingType: item.housingType
+    }))
+    loaded.value.price = true
+  } catch (e) {
+    console.error('❌ 시세 로딩 실패:', e)
   }
 }
-
-// listing map
 async function loadListings() {
   try {
-    const response = await fetch('/api/listing');
-    const data = await response.json();
-
-    const loaded = data.map((item) => ({
+    const res = await fetch('/api/listing')
+    const data = await res.json()
+    allListings.value = data.map(item => ({
       lat: item.latitude,
       lng: item.longitude,
       price: item.monthlyRent
         ? `월세 ${item.deposit}/${item.monthlyRent}`
         : item.transactionType === '전세'
-        ? `전세 ${item.deposit}`
-        : item.rentalCondition || '가격없음',
+          ? `전세 ${item.deposit}`
+          : item.rentalCondition || '가격없음',
       id: item.id,
-      title: item.listing,
-      address: item.address,
-      deposit: item.deposit,
-      rent: item.monthlyRent,
-      rentalCondition: item.rentalCondition,
-      details: item.details,
-      agency: item.agency,
-      transactionType: item.transactionType,
       housingType: item.housingType,
       areaInfo: item.areaInfo,
       areaInfo2:
-        item.areaInfo &&
-        typeof item.areaInfo === 'string' &&
-        item.areaInfo.includes('/')
-          ? Math.floor(
-              parseFloat(item.areaInfo.split('/')[1].replace('m', '')) /
-                3.305785
-            )
+        item.areaInfo && typeof item.areaInfo === 'string' && item.areaInfo.includes('/')
+          ? Math.floor(parseFloat(item.areaInfo.split('/')[1].replace('m', '')) / 3.305785)
           : null,
       floorInfo: item.floorInfo,
       direction: item.direction,
-    }));
-
-    listingMarkers.value = loaded.filter(
-      (marker) =>
-        selectedListingTypes.value.includes(marker.housingType) &&
-        // Area filter: 평수 filtering based on AreaSlider values
-        (minPyeong.value === null || marker.areaInfo2 >= minPyeong.value) &&
-        (maxPyeong.value === null || marker.areaInfo2 <= maxPyeong.value) &&
-        (selectedTransactionType.value === '' ||
-          marker.transactionType === selectedTransactionType.value)
-    );
-  } catch (error) {
-    console.error('❌ API 로딩 실패:', error);
+      transactionType: item.transactionType
+    }))
+    loaded.value.listing = true
+  } catch (e) {
+    console.error('❌ 매물 로딩 실패:', e)
   }
 }
 
-const onMapReady = (map) => {
-  mapInstance.value = map;
-  coor2address({ lat: lat.value, lng: lng.value });
+/** 초기엔 데이터 안 불러오고 위치만 */
+onMounted(() => {
+  if (navigator.geolocation) {
+    navigator.geolocation.getCurrentPosition(
+      pos => {
+        lat.value = pos.coords.latitude
+        lng.value = pos.coords.longitude
+        mapCenter.value = { lat: lat.value, lng: lng.value }
+      },
+      () => {}
+    )
+  }
+})
 
-  // Add map type control (top right)
-  const mapTypeControl = new window.kakao.maps.MapTypeControl();
-  map.addControl(mapTypeControl, window.kakao.maps.ControlPosition.TOPRIGHT);
-
-  // Add zoom control (right)
-  const zoomControl = new window.kakao.maps.ZoomControl();
-  map.addControl(zoomControl, window.kakao.maps.ControlPosition.RIGHT);
-
-  kakao.maps.event.addListener(map, 'dragend', () => updateURL(map));
-  kakao.maps.event.addListener(map, 'zoom_changed', () => updateURL(map));
-};
-
-// Updates the URL with the current map center and zoom level
-const updateURL = (mapInstance) => {
-  const center = mapInstance.getCenter();
-  const zoom = mapInstance.getLevel();
-
+/** 지도 이벤트 */
+function onMapReady(map) {
+  mapInstance.value = map
+  kakao.maps.event.addListener(map, 'dragend', () => updateURL(map))
+  kakao.maps.event.addListener(map, 'zoom_changed', () => updateURL(map))
+}
+function updateURL(map) {
+  const center = map.getCenter()
+  const zoom = map.getLevel()
   router.replace({
-    query: {
-      ...route.query,
-      center: `${center.getLat()},${center.getLng()}`,
-      zoomLevel: zoom,
-    },
-  });
-  lat.value = center.getLat();
-  lng.value = center.getLng();
-  level.value = zoom;
-  mapCenter.value = { lat: lat.value, lng: lng.value };
-  coor2address(mapCenter.value);
-};
+    query: { ...route.query, center: `${center.getLat()},${center.getLng()}`, zoomLevel: zoom }
+  })
+  lat.value = center.getLat()
+  lng.value = center.getLng()
+  level.value = zoom
+  mapCenter.value = { lat: lat.value, lng: lng.value }
+}
 
-// Gets the administrative district ("dong") from coordinates
-const coor2address = (coordinate) => {
-  const geocoder = new kakao.maps.services.Geocoder();
-  geocoder.coord2Address(coordinate.lng, coordinate.lat, (result, status) => {
-    if (status === kakao.maps.services.Status.OK) {
-      const dong = result[0]?.address?.region_3depth_name;
-      if (dong) {
-        currentDong.value = dong;
-        randomBgClass.value = getRandomTailwindBgClass(); // Update background class
+/** FilterBar 검색 → 장소 이동 */
+function onSearchLocation(keyword) {
+  const q = (keyword || '').trim()
+  if (!q) return
+  const places = new window.kakao.maps.services.Places()
+  places.keywordSearch(q, (result, status) => {
+    if (status === window.kakao.maps.services.Status.OK && result.length) {
+      const p = result[0]
+      const latNum = parseFloat(p.y)
+      const lngNum = parseFloat(p.x)
+      if (mapInstance.value) {
+        const center = new window.kakao.maps.LatLng(latNum, lngNum)
+        mapInstance.value.setCenter(center)
+        mapInstance.value.setLevel(4)
+        lat.value = latNum
+        lng.value = lngNum
+        mapCenter.value = { lat: latNum, lng: lngNum }
       }
     } else {
-      console.error('Geocoder failed with status:', status);
+      alert('검색 결과가 없습니다.')
     }
-  });
-};
-
-// Returns a random Tailwind CSS background class
-const getRandomTailwindBgClass = () => {
-  const randomIndex = Math.floor(Math.random() * tailwindBgColors.length);
-  return tailwindBgColors[randomIndex];
-};
-
-//map 다음 상세 페이지 이동
-function goToDetail(marker) {
-  if (!marker.lat || !marker.lng) {
-    console.error('❌ 마커 좌표 없음:', marker);
-    return;
-  }
-
-  router.push({
-    path: '/map/detail',
-    query: {
-      lat: marker.lat,
-      lng: marker.lng,
-      price: marker.price,
-    },
-  });
+  })
 }
 
-// listing toggle
-const isListingsVisible = ref(true);
+function toggleListings() { isListingsVisible.value = !isListingsVisible.value }
+function moveToCurrentLocation() {
+  if (!mapInstance.value || !currentLocation.value) return
+  const center = new window.kakao.maps.LatLng(currentLocation.value.lat, currentLocation.value.lng)
+  mapInstance.value.panTo(center)
+  mapInstance.value.setLevel(3)
+  updateURL(mapInstance.value)
+}
+function zoomIn()  { if (mapInstance.value) mapInstance.value.setLevel(mapInstance.value.getLevel() - 1) }
+function zoomOut() { if (mapInstance.value) mapInstance.value.setLevel(mapInstance.value.getLevel() + 1) }
 
-function toggleListings() {
-  isListingsVisible.value = !isListingsVisible.value;
-
-  if (isListingsVisible.value) {
-    // 마커 생성 로직 (지도에 매물 표시)
-  } else {
-    // 마커 제거 로직
-  }
+function goDetail(id) {
+  if (!id) return
+  router.push({ name: 'agencyDetail', params: { agencyId: String(id) } })
 }
 </script>
 
-<style>
-.custom-overlay {
-  padding: 5px 10px;
-  background-color: white;
-  border: 1px solid #ccc;
-  border-radius: 5px;
-  font-size: 12px;
-  font-weight: bold;
-  white-space: nowrap;
-  pointer-events: auto;
-}
-.dong-label {
+<style scoped>
+.top-controls {
   position: absolute;
-  top: 10px;
+  z-index: 101;
+}
+
+/* 칩 6개 한 줄 고정 */
+.chip-row {
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  top: 54px;
+  z-index: 100;
+  display: grid;
+  grid-template-columns: repeat(6, 56px);
+  gap: 6px;
+  justify-content: center;
+  overflow-x: auto;
+}
+
+.chip {
+  width: 56px;
+  height: 42px;
+  border-radius: 12px;
+  border: 1px solid var(--color-primary);
+  background: #fff;
+  cursor: pointer;
+  line-height: 1;
+  white-space: pre-line;
+  text-align: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px;
+  box-sizing: border-box;
+  letter-spacing: -0.03em;
+}
+/* 시세 버튼 비활성화 상태 */
+.chip.price:not(.active) {
+  border-color: #888fad;
+}
+
+/* 공통 활성화 상태 */
+.chip.active {
+  border-color: var(--color-primary);
+}
+
+/* 시세 버튼 활성화 */
+.chip.active.price {
+  background: #e6e8f0;
+  color: var(--color-primary);
+}
+
+/* 매물 버튼 활성화 */
+.chip.active.list {
+  background-color: var(--color-primary);
+  color: #fff;
+}
+
+.list-toggle-fab {
+  position: absolute;
   right: 10px;
-  z-index: 10;
-  padding: 6px 10px;
-  border-radius: 5px;
-  font-size: 18px;
-  color: white;
-  font-weight: bold;
-  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
+  top: 134px;
+  z-index: 101;
 }
 </style>

--- a/HomeWorry/src/pages/map/components/MapAgencyCard.vue
+++ b/HomeWorry/src/pages/map/components/MapAgencyCard.vue
@@ -20,46 +20,49 @@
     </div>
 
     <div class="actions">
-      <button class="btn-detail bodyMedium10px" @click="goDetail">상세보기</button>
+      <button
+        v-if="agencyId"
+        class="btn-detail bodyMedium10px"
+        @click="handleDetailClick"
+      >
+        상세보기
+      </button>
     </div>
   </div>
 </template>
 
 <script setup>
 import { computed } from 'vue';
-import { useRouter } from 'vue-router';
 
 const props = defineProps({
   agency: { type: Object, required: true }
 });
-defineEmits(['close']);
 
-const router = useRouter();
+const emit = defineEmits(['close', 'detail']);
 
-const isDial = computed(() => /^[\d\-\+\(\) ]+$/.test(props.agency?.phone || ''));
-const dialHref = computed(() =>
-  isDial.value
-    ? `tel:${(props.agency.phone || '').replaceAll(' ', '')}`
-    : 'https://www.kakaocorp.com/main'
-);
+const agencyId = computed(() => props.agency?.officeId);
 
-function goDetail() {
-  const id = props.agency?.officeId ?? props.agency?.id;
-  if (id == null) return;
-  router.push(`/agency/${id}`);
+function handleDetailClick() {
+  emit('detail', props.agency.officeId); 
 }
+
+// 전화번호 링크 관련 로직 (기존과 동일)
+const isDial = computed(() => /^[\d\-+() ]+$/.test(props.agency?.phone || ''));
+const dialHref = computed(() =>
+  isDial.value ? `tel:${(props.agency.phone || '').replaceAll(' ', '')}` : 'https://www.kakaocorp.com/main'
+);
 </script>
 
 <style scoped>
 .overlay-card {
   position: relative;
+  pointer-events: auto;
   width: 200px;
   height: 110px;
   padding: 10px;
   background: #fff;
-  border: 1px solid #e5e5ec;
   border-radius: 12px;
-  box-shadow: 0 4px 12px rgba(0,0,0,.12);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -68,7 +71,7 @@ function goDetail() {
 .header-row {
   display: flex;
   align-items: center;
-  justify-content: space-between; /* 제목 왼쪽, 닫기버튼 오른쪽 */
+  justify-content: space-between;
   gap: 6px;
 }
 
@@ -88,6 +91,7 @@ function goDetail() {
   color: var(--color-primary);
   font-size: 14px;
   line-height: 1;
+  padding: 0;
 }
 
 .content {
@@ -106,6 +110,11 @@ function goDetail() {
   text-overflow: ellipsis;
 }
 
+.phone {
+  color: inherit;
+  text-decoration: none;
+}
+
 .actions {
   display: flex;
   justify-content: flex-end;
@@ -119,5 +128,9 @@ function goDetail() {
   background: var(--color-primary);
   color: #fff;
   cursor: pointer;
+  text-align: center;
+  border: none;
+  font-family: inherit; 
+  padding: 0;
 }
 </style>

--- a/HomeWorry/src/pages/map/components/MapAgencyCard.vue
+++ b/HomeWorry/src/pages/map/components/MapAgencyCard.vue
@@ -1,0 +1,123 @@
+<template>
+  <div class="overlay-card" @click.stop>
+    <div class="header-row">
+      <div class="title bodyMedium12px">{{ agency.officeName }}</div>
+      <button class="close" @click="$emit('close')" aria-label="닫기">×</button>
+    </div>
+
+    <div class="content bodyLight10px">
+      <div class="line name">{{ agency.agentName }}</div>
+      <div class="line addr">{{ agency.address }}</div>
+      <a
+        v-if="agency.phone"
+        class="phone"
+        :href="dialHref"
+        :target="isDial ? undefined : '_blank'"
+        rel="noopener"
+      >
+        {{ agency.phone }}
+      </a>
+    </div>
+
+    <div class="actions">
+      <button class="btn-detail bodyMedium10px" @click="goDetail">상세보기</button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { useRouter } from 'vue-router';
+
+const props = defineProps({
+  agency: { type: Object, required: true }
+});
+defineEmits(['close']);
+
+const router = useRouter();
+
+const isDial = computed(() => /^[\d\-\+\(\) ]+$/.test(props.agency?.phone || ''));
+const dialHref = computed(() =>
+  isDial.value
+    ? `tel:${(props.agency.phone || '').replaceAll(' ', '')}`
+    : 'https://www.kakaocorp.com/main'
+);
+
+function goDetail() {
+  const id = props.agency?.officeId ?? props.agency?.id;
+  if (id == null) return;
+  router.push(`/agency/${id}`);
+}
+</script>
+
+<style scoped>
+.overlay-card {
+  position: relative;
+  width: 200px;
+  height: 110px;
+  padding: 10px;
+  background: #fff;
+  border: 1px solid #e5e5ec;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0,0,0,.12);
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+
+.header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between; /* 제목 왼쪽, 닫기버튼 오른쪽 */
+  gap: 6px;
+}
+
+.title {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 3px;
+}
+
+.close {
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  color: var(--color-primary);
+  font-size: 14px;
+  line-height: 1;
+}
+
+.content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  color: var(--color-black);
+  margin-bottom: 4px;
+}
+
+.line {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.btn-detail {
+  height: 18px;
+  width: 50px;
+  line-height: 18px;
+  border-radius: 12px;
+  background: var(--color-primary);
+  color: #fff;
+  cursor: pointer;
+}
+</style>

--- a/HomeWorry/src/pages/mypage/ListingBookmark.vue
+++ b/HomeWorry/src/pages/mypage/ListingBookmark.vue
@@ -67,45 +67,13 @@ onMounted(() => {
 })
 
 async function fetchListingList(){
-  // try {
-  //   // 북마크 된 매물 목록 조회
-  //   const res = await axios.get(`http://localhost:8080/api/listing/favorite/${userToken}`)
-  //   listings.value = res.data
-  // } catch (e) {
-  //   alert('찜한 매물 목록을 불러오지 못했습니다.')
-  // }
-
-  // 목 데이터 삽입
-  listings.value = [
-    {
-      id: 1,
-      listingName: '해피빌 101동',
-      transactionType: '월세',
-      deposit: 1000,
-      monthlyRent: 50,
-      address: '서울특별시 강남구 테헤란로 123',
-      housingType: '오피스텔',
-      areaInfo: '18평',
-      floorInfo: '3층',
-      direction: '남향',
-      isFavorite: true,
-      price: 50000,
-    },
-    {
-      id: 2,
-      listingName: '프라임아파트',
-      transactionType: '전세',
-      deposit: 20000,
-      monthlyRent: 0,
-      address: '서울특별시 송파구 올림픽로 45',
-      housingType: '아파트',
-      areaInfo: '25평',
-      floorInfo: '15층',
-      direction: '동향',
-      isFavorite: true,
-      price: 200000,
-    },
-  ]
+  try {
+    // 북마크 된 매물 목록 조회
+    const res = await axios.get(`http://localhost:8080/api/listing/favorite/${userToken}`)
+    listings.value = res.data
+  } catch (e) {
+    alert('찜한 매물 목록을 불러오지 못했습니다.')
+  }
 }
 
 const sortedList = computed(() => listings.value)


### PR DESCRIPTION
## **📍 PR 타입**

- [x]  기능 추가
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ]  기타 사소한 수정

## **❗️ 관련 이슈 링크**

Close #171 

## **🔁 변경 사항**
- 중개사무소 지도 상세정보 컴포넌트 구현하였습니다.
- 위의 상세정보 컴포넌트에 '상세보기'버튼을 추가하여, 중개사무소로의 이동까지 구현하였습니다.
- Footer사이즈를 전체적으로 2px 정도 줄였습니다.
- 중개사무소 페이지내에션 개수를 20개에서 10개로 줄였습니다.
- Footer에서 지도 탭 이동 시 뜨는 페이지를 구현하였습니다.

## **📸 스크린샷**
<img width="300" height="auto" alt="image" src="https://github.com/user-attachments/assets/8f51c4d7-95fd-4c96-a160-b0658c2aeb22" />
<img width="300" height="auto" alt="image" src="https://github.com/user-attachments/assets/1f100788-54e9-4cbf-a266-b261c3e9fdac" />


## **👀 기타 더 이야기해 볼 점**
- 중개사무소 지도 페이지의 클러스터링 오류를 잡지 못하였습니다. 대신 중개사무소 지도 진입 레벨을 2에서 3으로 높이고 클러스터링 없이 전체 핀을 다 띄우는 것으로 처리하였습니다. 

## **✅ 체크 리스트**

- [x]  변경 내용에 대한 테스트를 진행했어요.
- [x]  프로그램이 정상적으로 동작해요.
- [x]  PR에 적절한 라벨을 선택했어요.
- [x]  불필요한 코드는 삭제했어요.
